### PR TITLE
fix: enable to overwrite default highlights

### DIFF
--- a/lua/telescope/_extensions/egrepify.lua
+++ b/lua/telescope/_extensions/egrepify.lua
@@ -101,10 +101,10 @@ local egrep_config = require "telescope._extensions.egrepify.config"
 local egrep_picker = require "telescope._extensions.egrepify.picker"
 
 -- Initialize highlights
-vim.api.nvim_set_hl(0, "EgrepifyFile", { link = "Title" })
-vim.api.nvim_set_hl(0, "EgrepifySuffix", { link = "Comment" })
-vim.api.nvim_set_hl(0, "EgrepifyLnum", { link = "Constant" })
-vim.api.nvim_set_hl(0, "EgrepifyCol", { link = "Constant" })
+vim.api.nvim_set_hl(0, "EgrepifyFile", { link = "Title", default = true })
+vim.api.nvim_set_hl(0, "EgrepifySuffix", { link = "Comment", default = true })
+vim.api.nvim_set_hl(0, "EgrepifyLnum", { link = "Constant", default = true })
+vim.api.nvim_set_hl(0, "EgrepifyCol", { link = "Constant", default = true })
 
 local egrepify = function(opts)
   opts = opts or {}


### PR DESCRIPTION
Plugins should respect customized highlights if they already exist.