### PR TITLE
fix: enable to open files with supplied cwd

### DIFF
--- a/lua/telescope/_extensions/egrepify/entry_maker.lua
+++ b/lua/telescope/_extensions/egrepify/entry_maker.lua
@@ -1,7 +1,7 @@
 local ts_utils = require "telescope.utils"
 local egrep_conf = require("telescope._extensions.egrepify.config").values
 
-local os_sep = require "plenary.path".path.sep
+local os_sep = require("plenary.path").path.sep
 local str = require "plenary.strings"
 
 local find_whitespace = function(string_)
@@ -182,7 +182,8 @@ return function(opts)
         local lnum = data["line_number"]
         local col = start + 1
         local entry = {
-          filename = opts.cwd .. os_sep .. filename,
+          filename = filename,
+          path = opts.cwd .. os_sep .. filename,
           lnum = lnum,
           text = text,
           -- byte offset zero-indexed
@@ -207,7 +208,8 @@ return function(opts)
         return {
           value = filename,
           ordinal = filename,
-          filename = opts.cwd .. os_sep .. filename,
+          filename = filename,
+          path = opts.cwd .. os_sep .. filename,
           kind = kind,
           display = function()
             return opts.title_display(filename, data, opts)

--- a/lua/telescope/_extensions/egrepify/entry_maker.lua
+++ b/lua/telescope/_extensions/egrepify/entry_maker.lua
@@ -1,7 +1,7 @@
 local ts_utils = require "telescope.utils"
 local egrep_conf = require("telescope._extensions.egrepify.config").values
 
-local Path = require "plenary.path"
+local os_sep = require "plenary.path".path.sep
 local str = require "plenary.strings"
 
 local find_whitespace = function(string_)
@@ -182,7 +182,7 @@ return function(opts)
         local lnum = data["line_number"]
         local col = start + 1
         local entry = {
-          filename = opts.cwd .. Path.path.sep .. data["path"]["text"],
+          filename = opts.cwd .. os_sep .. filename,
           lnum = lnum,
           text = text,
           -- byte offset zero-indexed
@@ -207,7 +207,7 @@ return function(opts)
         return {
           value = filename,
           ordinal = filename,
-          filename = filename,
+          filename = opts.cwd .. os_sep .. filename,
           kind = kind,
           display = function()
             return opts.title_display(filename, data, opts)

--- a/lua/telescope/_extensions/egrepify/entry_maker.lua
+++ b/lua/telescope/_extensions/egrepify/entry_maker.lua
@@ -182,7 +182,7 @@ return function(opts)
         local lnum = data["line_number"]
         local col = start + 1
         local entry = {
-          filename = Path:new(opts.cwd, data["path"]["text"]).filename,
+          filename = opts.cwd .. Path.path.sep .. data["path"]["text"],
           lnum = lnum,
           text = text,
           -- byte offset zero-indexed

--- a/lua/telescope/_extensions/egrepify/entry_maker.lua
+++ b/lua/telescope/_extensions/egrepify/entry_maker.lua
@@ -1,6 +1,7 @@
 local ts_utils = require "telescope.utils"
 local egrep_conf = require("telescope._extensions.egrepify.config").values
 
+local Path = require "plenary.path"
 local str = require "plenary.strings"
 
 local function collect(tbl)
@@ -164,7 +165,7 @@ return function(opts)
         local start = not vim.tbl_isempty(data["submatches"]) and data["submatches"][1]["start"] or 0
         -- local line_displayer = entry_display.create(opts.display_line_create)
         local entry = {
-          filename = data["path"]["text"],
+          filename = Path:new(opts.cwd, data["path"]["text"]).filename,
           lnum = data["line_number"],
           -- byte offset zero-indexed
           col = start + 1,


### PR DESCRIPTION
I noticed I cannot open files with `cwd=/path/to/foo/dir` option.

```bash
# Run Neovim in my home directory
~ $ nvim
```

```vim
" And open egrepify with specifying cwd
:Telescope egrepify cwd=/path/to/foo/dir
```

Then I select `bar/init.lua`, it tries to open `~/bar/init.lua` instead of `/path/to/foo/dir/bar/init.lua`.

I fixed this with joining `cwd` value and relative path in `filename`. Is this a correct way to solve this? How do you think?