### PR TITLE
fix(entry_maker): handle absolute paths

### DIFF
--- a/lua/telescope/_extensions/egrepify/entry_maker.lua
+++ b/lua/telescope/_extensions/egrepify/entry_maker.lua
@@ -183,7 +183,8 @@ return function(opts)
         local col = start + 1
         local entry = {
           filename = filename,
-          path = opts.cwd .. os_sep .. filename,
+          -- rg --json returns absolute paths when expl. directories are grepped
+          path = opts.searches_dirs and filename or opts.cwd .. os_sep .. filename,
           lnum = lnum,
           text = text,
           col = col,
@@ -207,7 +208,8 @@ return function(opts)
           value = filename,
           ordinal = filename,
           filename = filename,
-          path = opts.cwd .. os_sep .. filename,
+          -- rg --json returns absolute paths when expl. directories are grepped
+          path = opts.searches_dirs and filename or opts.cwd .. os_sep .. filename,
           kind = kind,
           display = function()
             return opts.title_display(filename, data, opts)


### PR DESCRIPTION
When a directory is passed in `opts.search_dirs`
`rg --json` returns absolute file paths.
These are now handled correctly in the entry maker.

Closes #27 