### PR TITLE
fix(entry_maker): add `cwd` to entry for usage with trouble.nvim and maybe other similar plugins

### DIFF
--- a/lua/telescope/_extensions/egrepify/entry_maker.lua
+++ b/lua/telescope/_extensions/egrepify/entry_maker.lua
@@ -185,6 +185,7 @@ return function(opts)
           filename = filename,
           -- rg --json returns absolute paths when expl. directories are grepped
           path = opts.searches_dirs and filename or opts.cwd .. os_sep .. filename,
+          cwd = opts.cwd,
           lnum = lnum,
           text = text,
           col = col,
@@ -210,6 +211,7 @@ return function(opts)
           filename = filename,
           -- rg --json returns absolute paths when expl. directories are grepped
           path = opts.searches_dirs and filename or opts.cwd .. os_sep .. filename,
+          cwd = opts.cwd,
           kind = kind,
           display = function()
             return opts.title_display(filename, data, opts)


### PR DESCRIPTION
As used in e.g. https://github.com/folke/trouble.nvim/blob/f1168feada93c0154ede4d1fe9183bf69bac54ea/lua/trouble/providers/telescope.lua#L15. Otherwise trouble.nvim thows a "no such file or directory" error when a custom `cwd` is used.