### PR TITLE
first index error fix

### DIFF
--- a/lua/telescope/_extensions/egrepify/config.lua
+++ b/lua/telescope/_extensions/egrepify/config.lua
@@ -28,7 +28,7 @@ _TelescopeEgrepifyConfig = {
       ["<C-z>"] = egrep_actions.toggle_prefixes,
       ["<C-a>"] = egrep_actions.toggle_and,
       ["<C-r>"] = egrep_actions.toggle_permutations,
-      ["<c-space>"] = actions.to_fuzzy_refine
+      ["<c-space>"] = actions.to_fuzzy_refine,
     },
   },
   prefixes = {
@@ -65,8 +65,13 @@ _TelescopeEgrepifyConfig = {
       actions[key]:enhance {
         post = function()
           local entry = action_state.get_selected_entry()
+
           if entry and entry.kind == "begin" then
-            actions[key](prompt_bufnr)
+            if entry.index == 1 then
+              actions["move_selection_next"](prompt_bufnr)
+            else
+              actions[key](prompt_bufnr)
+            end
           end
         end,
       }


### PR DESCRIPTION
If you move the arrow key up at the first index, you will end up in an infinite loop.

I don't think it's a good idea, but you shouldn't have any problems.

## Press the up arrow key in the first row
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/d0c00960-93e4-4fd2-83de-d5ab8c1c2af7">



## A problem occurred
<img width="1269" alt="image" src="https://github.com/user-attachments/assets/1fa0f63e-dc2a-4fae-9dcb-cb0b192f5989">

