### PR TITLE
fix(entry_maker): use the un-transformed filename to determine title's devicon

### DIFF
--- a/lua/telescope/_extensions/egrepify/entry_maker.lua
+++ b/lua/telescope/_extensions/egrepify/entry_maker.lua
@@ -211,7 +211,7 @@ end
 local function title_display(filename, _, opts)
   local display_filename = ts_utils.transform_path({ cwd = opts.cwd }, filename)
   local suffix_ = opts.title_suffix or ""
-  local display, hl_group = ts_utils.transform_devicons(display_filename, display_filename .. suffix_, false)
+  local display, hl_group = ts_utils.transform_devicons(filename, display_filename .. suffix_, false)
   local offset = find_whitespace(display)
   local end_filename = offset + #display_filename
   local end_suffix = end_filename + #opts.title_suffix


### PR DESCRIPTION
To determine the devicon for a filename, we should avoid passing in the **transformed** display name, as the result can vary depending on the `path_display` telescope setting, potentially leading to undesired outcomes.

For instance, with the following telescope `path_display` setting, the result can be seen in the attached image.

```lua
    require("telescope").setup {
        defaults = {
             path_display = { "filename_first" },
        }
    }

```

![image](https://github.com/user-attachments/assets/e3e9dfa3-9490-4cd2-965e-5a7a987d1b77)
