### PR TITLE
TS highlighter that directly parse result window

### DIFF
--- a/lua/telescope/_extensions/egrepify/entry_maker.lua
+++ b/lua/telescope/_extensions/egrepify/entry_maker.lua
@@ -201,18 +201,6 @@ local function line_display(entry, data, opts, ts_highlights)
       end
     end
   end
-  if opts.results_ts_hl then
-    if ts_highlights[entry.path] == nil then
-      ts_highlights[entry.path] = get_ts_highlights(entry.path)
-    end
-    if ts_highlights[entry.path] and ts_highlights[entry.path][entry.lnum] then
-      for ts_col, hl in pairs(ts_highlights[entry.path][entry.lnum]) do
-        if not covered_ids[ts_col] then
-          highlights[#highlights + 1] = { { begin + ts_col, begin + ts_col + 1 }, hl }
-        end
-      end
-    end
-  end
   return display, highlights
 end
 

--- a/lua/telescope/_extensions/egrepify/picker.lua
+++ b/lua/telescope/_extensions/egrepify/picker.lua
@@ -7,6 +7,7 @@ local sorters = require "telescope.sorters"
 local conf = require("telescope.config").values
 local egrep_conf = require("telescope._extensions.egrepify.config").values
 local actions = require "telescope.actions"
+local TSInjector = require "telescope._extensions.egrepify.treesitter"
 
 local flatten = vim.tbl_flatten
 
@@ -214,6 +215,60 @@ function Picker.picker(opts)
       preview_fn(previewer, entry, status)
     end
   end
+  local entry_adder = picker.entry_adder
+  local regions = {}
+  local valid_lines = {}
+  picker.entry_adder = function(picker_, index, entry, _, insert)
+    entry_adder(picker_, index, entry, _, insert)
+    if not entry.kind == "match" then
+      return
+    end
+
+    local row = picker_:get_row(index)
+    local line_count = vim.api.nvim_buf_line_count(picker_.results_bufnr)
+    if row > line_count then
+      return
+    end
+    local line = vim.api.nvim_buf_get_lines(picker_.results_bufnr, row, row + 1, false)[1]
+    local ft = vim.filetype.match { filename = entry.filename }
+    if ft == nil then
+      return
+    end
+    if regions[ft] == nil then
+      regions[ft] = {}
+    end
+
+    if entry.text then
+      local first_pos = string.find(line, entry.text, 1, true)
+      if first_pos == nil then
+        return
+      end
+      first_pos = first_pos - 1
+      -- clear row for FT that used to be in that row
+      if valid_lines[row] and regions[valid_lines[row][1]] then
+        table.remove(regions[valid_lines[row][1]], valid_lines[row][2])
+      end
+      table.insert(regions[ft], { { row, first_pos, row, line:len() } })
+      local offset = #regions[ft]
+      -- store filetype and table offset for line that may have to be invalidated
+      valid_lines[row] = { ft, offset }
+      TSInjector.attach(picker_.results_bufnr, regions)
+    end
+  end
+
+  -- invalidate regions after every keystroke
+  local on_input_filter_cb = picker._on_input_filter_cb
+  picker._on_input_filter_cb = function(prompt)
+    regions = {}
+    return on_input_filter_cb(prompt)
+  end
+
+  -- "refreshes" results buffer without retriggering `rg` unlike picker:refresh()
+  -- when `rg` is finished
+  table.insert(picker._completion_callbacks, function()
+    picker:set_selection(picker:get_selection_row())
+  end)
+
   -- caching opts to be able to remove `title` from opts for entry maker for fuzzy refine
   picker._opts = opts
   picker.use_prefixes = vim.F.if_nil(opts.use_prefixes, egrep_conf.use_prefixes)

--- a/lua/telescope/_extensions/egrepify/picker.lua
+++ b/lua/telescope/_extensions/egrepify/picker.lua
@@ -217,7 +217,6 @@ function Picker.picker(opts)
   end
   local entry_adder = picker.entry_adder
   local regions = {}
-  local valid_lines = {}
   picker.entry_adder = function(picker_, index, entry, _, insert)
     entry_adder(picker_, index, entry, _, insert)
     if not entry.kind == "match" then
@@ -245,13 +244,7 @@ function Picker.picker(opts)
       end
       first_pos = first_pos - 1
       -- clear row for FT that used to be in that row
-      if valid_lines[row] and regions[valid_lines[row][1]] then
-        table.remove(regions[valid_lines[row][1]], valid_lines[row][2])
-      end
       table.insert(regions[ft], { { row, first_pos, row, line:len() } })
-      local offset = #regions[ft]
-      -- store filetype and table offset for line that may have to be invalidated
-      valid_lines[row] = { ft, offset }
       TSInjector.attach(picker_.results_bufnr, regions)
     end
   end

--- a/lua/telescope/_extensions/egrepify/treesitter.lua
+++ b/lua/telescope/_extensions/egrepify/treesitter.lua
@@ -1,0 +1,88 @@
+local log = require "telescope.log"
+
+---@alias trouble.LangRegions table<string, number[][][]>
+
+local M = {}
+
+M.cache = {} ---@type table<number, table<string,{parser: vim.treesitter.LanguageTree, highlighter:vim.treesitter.highlighter, enabled:boolean}>>
+local ns = vim.api.nvim_create_namespace "egrepify.highlighter"
+
+local TSHighlighter = vim.treesitter.highlighter
+
+local function wrap(name)
+  return function(_, win, buf, ...)
+    if not M.cache[buf] then
+      return false
+    end
+    for _, hl in pairs(M.cache[buf] or {}) do
+      if hl.enabled then
+        TSHighlighter.active[buf] = hl.highlighter
+        TSHighlighter[name](_, win, buf, ...)
+      end
+    end
+    TSHighlighter.active[buf] = nil
+  end
+end
+
+M.did_setup = false
+function M.setup()
+  if M.did_setup then
+    return
+  end
+  M.did_setup = true
+
+  vim.api.nvim_set_decoration_provider(ns, {
+    on_win = wrap "_on_win",
+    on_line = wrap "_on_line",
+  })
+
+  vim.api.nvim_create_autocmd("BufWipeout", {
+    group = vim.api.nvim_create_augroup("egrepify.treesitter.hl", { clear = true }),
+    callback = function(ev)
+      M.cache[ev.buf] = nil
+    end,
+  })
+end
+
+---@param buf number
+---@param regions trouble.LangRegions
+function M.attach(buf, regions)
+  M.setup()
+  M.cache[buf] = M.cache[buf] or {}
+  for lang in pairs(M.cache[buf]) do
+    M.cache[buf][lang].enabled = regions[lang] ~= nil
+  end
+
+  for lang in pairs(regions) do
+    M._attach_lang(buf, lang, regions[lang])
+  end
+end
+
+---@param buf number
+---@param lang? string
+function M._attach_lang(buf, lang, regions)
+  lang = lang or "markdown"
+  lang = lang == "markdown" and "markdown_inline" or lang
+
+  M.cache[buf] = M.cache[buf] or {}
+
+  if not M.cache[buf][lang] then
+    local ok, parser = pcall(vim.treesitter.languagetree.new, buf, lang)
+    if not ok then
+      local msg = "nvim-treesitter parser missing `" .. lang .. "`"
+      log.debug(msg)
+      return
+    end
+    parser:set_included_regions(regions)
+    M.cache[buf][lang] = {
+      parser = parser,
+      highlighter = TSHighlighter.new(parser),
+    }
+  end
+  M.cache[buf][lang].enabled = true
+  local parser = M.cache[buf][lang].parser
+
+  parser:set_included_regions(regions)
+end
+
+return M


### PR DESCRIPTION
This is a POC that steal the idea from [trouble.nvim](https://github.com/folke/trouble.nvim/blob/85154cedf9b5bf64e56046d493cad7afc3416621/lua/trouble/view/treesitter.lua)

Use `nvim_set_decoration_provider` and `set_included_regions` to parse the result window on the fly, in every key stroke, but only in the visible several lines, so each round of parsing only requires 3ms. Current implementation will freeze for 0.5 seconds when there are too many files, tested by searching `func` in gopls repo, while after the initial parse, later keystrokes do not need extra parsing time.

Also the  TelescopePreviewerLoaded is not a good idea, but can't find better  place to inject the callback, this pr should works with default config with minimal setup. the detail needs to adjust if you like this idea.