### PR TITLE
fix(perf): avoid wrapping every time in calling

### DIFF
--- a/lua/telescope/_extensions/egrepify/treesitter.lua
+++ b/lua/telescope/_extensions/egrepify/treesitter.lua
@@ -31,11 +31,19 @@ function M.setup()
   end
   M.did_setup = true
 
+  local on_line
+  if vim.fn.has "nvim-0.12" then
+    local on_range = wrap "_on_range"
+    on_line = function(_, win, buf, row)
+      return on_range(_, win, buf, row, 0, row + 1, 0)
+    end
+  else
+    on_line = wrap "_on_line"
+  end
+
   vim.api.nvim_set_decoration_provider(ns, {
     on_win = wrap "_on_win",
-    on_line = vim.fn.has "nvim-0.12" and function(_, win, buf, row)
-      wrap "_on_range"(_, win, buf, row, 0, row + 1, 0)
-    end or wrap "_on_line",
+    on_line = on_line,
   })
 
   vim.api.nvim_create_autocmd("BufWipeout", {


### PR DESCRIPTION
And the previous code does not return the value from `wrap()`. This commit also solves it.

This is a follow-up PR for #58.